### PR TITLE
Update SystemPay.php

### DIFF
--- a/src/Tlconseil/SystempayBundle/Service/SystemPay.php
+++ b/src/Tlconseil/SystempayBundle/Service/SystemPay.php
@@ -53,7 +53,7 @@ class SystemPay
         $this->entityManager = $entityManager;
         foreach ($this->mandatoryFields as $field => $value)
             $this->mandatoryFields[$field] = $container->getParameter(sprintf('tlconseil_systempay.%s', $field));
-        if ($this->mandatoryFields['ctx_mode'])
+        if ($this->mandatoryFields['ctx_mode'] == "TEST")
             $this->key = $container->getParameter('tlconseil_systempay.key_dev');
         else
             $this->key = $container->getParameter('tlconseil_systempay.key_prod');


### PR DESCRIPTION
CTX_MODE was wrongfully tested for true => now the value tested for is `if ($this->mandatoryFields['ctx_mode'] == "TEST")`
In the `__construct()` method of the service. It allows the service to get the right confoguration value : either `key_prod` or `key_dev`.
