### PR TITLE
quote special characters in YAML config files

### DIFF
--- a/src/Tlconseil/SystempayBundle/Resources/config/services.yml
+++ b/src/Tlconseil/SystempayBundle/Resources/config/services.yml
@@ -2,7 +2,7 @@ services:
 
     tlconseil.systempay:
         class: Tlconseil\SystempayBundle\Service\SystemPay
-        arguments: [@doctrine.orm.entity_manager, @service_container]
+        arguments: ['@doctrine.orm.entity_manager', '@service_container']
 
     tlconseil.systempay.twig_extension:
         class: Tlconseil\SystempayBundle\Twig\TwigExtension


### PR DESCRIPTION
The @ character is reserved in the YAML specs and therefore should
not be used as the first character in an unquoted scalar value.

SF3 raises this issue