### PR TITLE
Fix service.yml for Symfony 3.x

### DIFF
--- a/.idea/SystempayBundle.iml
+++ b/.idea/SystempayBundle.iml
@@ -4,15 +4,5 @@
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module-library">
-      <library name="PHP Runtime" type="php">
-        <CLASSES>
-          <root url="jar://$APPLICATION_HOME_DIR$/plugins/php/lib/php.jar!/stubs/standard" />
-        </CLASSES>
-        <SOURCES>
-          <root url="jar://$APPLICATION_HOME_DIR$/plugins/php/lib/php.jar!/stubs/standard" />
-        </SOURCES>
-      </library>
-    </orderEntry>
   </component>
 </module>

--- a/.idea/SystempayBundle.iml
+++ b/.idea/SystempayBundle.iml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library">
+      <library name="PHP Runtime" type="php">
+        <CLASSES>
+          <root url="jar://$APPLICATION_HOME_DIR$/plugins/php/lib/php.jar!/stubs/standard" />
+        </CLASSES>
+        <SOURCES>
+          <root url="jar://$APPLICATION_HOME_DIR$/plugins/php/lib/php.jar!/stubs/standard" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/SystempayBundle.iml" filepath="$PROJECT_DIR$/.idea/SystempayBundle.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/Tlconseil/SystempayBundle/DependencyInjection/Configuration.php
+++ b/src/Tlconseil/SystempayBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,6 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('ctx_mode')->defaultValue('TEST')->end()
             ->scalarNode('page_action')->defaultValue('PAYMENT')->end()
             ->scalarNode('action_mode')->defaultValue('INTERACTIVE')->end()
-            ->scalarNode('payment_config')->defaultValue('SINGLE')->end()
             ->scalarNode('version')->defaultValue('V2')->end()
             ->scalarNode('language')->defaultValue('fr')->end()
             ->scalarNode('redirect_success_timeout')->defaultValue('1')->end()

--- a/src/Tlconseil/SystempayBundle/Resources/config/services.yml
+++ b/src/Tlconseil/SystempayBundle/Resources/config/services.yml
@@ -1,8 +1,9 @@
 services:
-
     tlconseil.systempay:
         class: Tlconseil\SystempayBundle\Service\SystemPay
-        arguments: ['@doctrine.orm.entity_manager', '@service_container']
+        arguments:
+            - "@doctrine.orm.entity_manager"
+            - "@service_container"
 
     tlconseil.systempay.twig_extension:
         class: Tlconseil\SystempayBundle\Twig\TwigExtension

--- a/src/Tlconseil/SystempayBundle/Service/SystemPay.php
+++ b/src/Tlconseil/SystempayBundle/Service/SystemPay.php
@@ -25,7 +25,6 @@ class SystemPay
         'action_mode' => null,
         'ctx_mode' => null,
         'page_action' => null,
-        'payment_config' => null,
         'site_id' => null,
         'version' => null,
         'redirect_success_message' => null,
@@ -90,13 +89,14 @@ class SystemPay
      * 95 € = 9500
      * @return $this
      */
-    public function init($currency = 978, $amount = 1000)
+    public function init($currency = 978, $amount = 1000, $paymentConfig = "SINGLE")
     {
         $this->transaction = $this->newTransaction($currency, $amount);
         $this->mandatoryFields['amount'] = $amount;
         $this->mandatoryFields['currency'] = $currency;
         $this->mandatoryFields['trans_id'] = sprintf('%06d', $this->transaction->getId());
         $this->mandatoryFields['trans_date'] = gmdate('YmdHis');
+        $this->mandatoryFields['payment_config'] = $paymentConfig;
         return $this;
     }
 


### PR DESCRIPTION
I found a bug when i was installing the bundle on Symfony 3, the notation was deprecated, so I fix it. 